### PR TITLE
feat: implementa verificação nativa de root/jailbreak na inicialização

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version History
 
+### 3.2.0
+
+- Adicionada verificação automática de root/jailbreak na inicialização do aplicativo
+- O aplicativo agora é encerrado automaticamente se root/jailbreak for detectado na inicialização
+- Mantida a funcionalidade de verificação manual através das APIs existentes
+
 ### 3.1.0
 
 - bump `rootbeer` from `0.0.9` to `0.1.0` (see [rootbeer#170](scottyab/rootbeer#170) [rootbeer#171](scottyab/rootbeer#171))

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ don’t forget to add `"cydia"` in `LSApplicationQueriesSchemes` key of `info.pl
 
 ## Usage in Javascript
 
+### Verificação Automática
+O plugin agora realiza uma verificação automática de root/jailbreak na inicialização do aplicativo. Se for detectado root/jailbreak, o aplicativo tentará se fechar automaticamente.
+
+### Verificação Manual
+Você também pode realizar verificações manuais quando desejar:
+
 ```js
 // available => iOS + Android
 IRoot.isRooted(successCallback, failureCallback);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-iroot",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Jailbreak/Root Detection Plugin for Apache Cordova",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<plugin id="cordova-plugin-iroot" version="3.1.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-iroot" version="3.2.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>iRoot</name>
     <author>Elderov Ali (info@cyberkatze.de)</author>
 

--- a/src/ios/IRoot.m
+++ b/src/ios/IRoot.m
@@ -62,6 +62,17 @@ enum {
 
 @implementation IRoot
 
+- (void)pluginInitialize {
+    // Executa verificação de jailbreak na inicialização
+    if ([self jailbroken]) {
+        NSLog(@"[IRoot] Dispositivo com jailbreak detectado na inicialização. Encerrando aplicativo.");
+        // Encerra o app
+        exit(0);
+    } else {
+        NSLog(@"[IRoot] Verificação de jailbreak na inicialização: dispositivo seguro");
+    }
+}
+
 - (void) isRooted:(CDVInvokedUrlCommand*)command;
 {
     CDVPluginResult *pluginResult;


### PR DESCRIPTION
- Adiciona verificação automática de root/jailbreak na inicialização do app
- Implementa método initialize() no Android para verificação nativa
- Implementa método pluginInitialize no iOS para verificação nativa
- Encerra o app automaticamente se detectado root/jailbreak
- Atualiza documentação e changelog
- Incrementa versão do plugin para 3.2.0

BREAKING CHANGE: O app agora é encerrado automaticamente se detectado root/jailbreak na inicialização